### PR TITLE
Enable less strict javadoc generation for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,5 +416,36 @@
         </repository>
     </repositories>
 
-
+	<profiles>
+	  <profile>
+	    <id>doclint-java8-disable</id>
+	    <activation>
+	      <jdk>[1.8,)</jdk>
+	    </activation>
+	
+	    <build>
+	      <plugins>
+	        <plugin>
+	          <groupId>org.apache.maven.plugins</groupId>
+	          <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </execution>
+                </executions>
+	          <configuration>
+	            <additionalparam>-Xdoclint:none</additionalparam>
+	          </configuration>
+	        </plugin>
+	      </plugins>
+	    </build>
+	  </profile>
+	</profiles>
 </project>


### PR DESCRIPTION
In Java 8, JavaDoc is very strict. So the following example will generate an error while javadoc processing:
```
@author John Doe <john.doe@example.org>
```
The added profile uses the lenient mode of Java 7.